### PR TITLE
URL Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ bin/
 *.war
 *.ear
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 *.class

--- a/src/test/resources/api_without_example_in_request_body.raml
+++ b/src/test/resources/api_without_example_in_request_body.raml
@@ -18,8 +18,8 @@ baseUri: http://localhost:8081/
         schema: |
           {
             "type": "object",
-            "$schema": "http://json-schema.org/draft-03/schema",
-            "id": "http://jsonschema.net",
+            "$schema": "https://json-schema.org/draft-03/schema",
+            "id": "https://jsonschema.net",
             "required": true,
             "properties": {
               "songTitle": {

--- a/src/test/resources/api_without_example_in_response_body.raml
+++ b/src/test/resources/api_without_example_in_response_body.raml
@@ -27,8 +27,8 @@ baseUri: http://localhost:8081/
             schema: |
               {
                 "type": "object",
-                "$schema": "http://json-schema.org/draft-03/schema",
-                "id": "http://jsonschema.net",
+                "$schema": "https://json-schema.org/draft-03/schema",
+                "id": "https://jsonschema.net",
                 "required": true,
                 "properties": {
                   "songTitle": {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://json-schema.org/draft-03/schema with 2 occurrences migrated to:  
  https://json-schema.org/draft-03/schema ([https](https://json-schema.org/draft-03/schema) result 200).
* [ ] http://jsonschema.net with 2 occurrences migrated to:  
  https://jsonschema.net ([https](https://jsonschema.net) result 200).
* [ ] http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8081 with 1 occurrences
* http://localhost:8081/ with 8 occurrences
* http://localhost:8081/api/2.5 with 1 occurrences